### PR TITLE
Removed stackSize variable from compiler

### DIFF
--- a/src/main/java/ie/francis/lisp/Environment.java
+++ b/src/main/java/ie/francis/lisp/Environment.java
@@ -1,7 +1,7 @@
 /*
- * (c) 2023 Francis McNamee
+ * (c) 2024 Francis McNamee
  * */
-
+ 
 package ie.francis.lisp;
 
 import ie.francis.lisp.exception.UndefinedSymbolException;
@@ -15,8 +15,9 @@ public class Environment {
 
   public Environment() {}
 
-  public static void put(Symbol name, Object value) {
+  public static Object put(Symbol name, Object value) {
     Environment.map.put(name, value);
+    return null;
   }
 
   public static Object get(Symbol name) {

--- a/src/main/java/ie/francis/lisp/Environment.java
+++ b/src/main/java/ie/francis/lisp/Environment.java
@@ -1,7 +1,7 @@
 /*
- * (c) 2024 Francis McNamee
+ * (c) 2023 Francis McNamee
  * */
- 
+
 package ie.francis.lisp;
 
 import ie.francis.lisp.exception.UndefinedSymbolException;

--- a/src/main/java/ie/francis/lisp/Environment.java
+++ b/src/main/java/ie/francis/lisp/Environment.java
@@ -1,7 +1,7 @@
 /*
- * (c) 2023 Francis McNamee
+ * (c) 2024 Francis McNamee
  * */
-
+ 
 package ie.francis.lisp;
 
 import ie.francis.lisp.exception.UndefinedSymbolException;

--- a/src/main/java/ie/francis/lisp/compiler/Compiler.java
+++ b/src/main/java/ie/francis/lisp/compiler/Compiler.java
@@ -32,7 +32,6 @@ public class Compiler {
 
   private final LocalTable locals;
 
-
   private boolean isMacro;
 
   public Compiler() {
@@ -452,7 +451,7 @@ public class Compiler {
       Metadata metadata = _compile(value);
       locals.add(symbol.getValue(), metadata);
       mv.visitVarInsn(ASTORE, locals.get(symbol.getValue()).getLocalId());
-            // Move to next assignment if there is one
+      // Move to next assignment if there is one
       assignments = assignments.getCdr().getCdr();
     }
 

--- a/src/main/java/ie/francis/lisp/compiler/Compiler.java
+++ b/src/main/java/ie/francis/lisp/compiler/Compiler.java
@@ -32,13 +32,11 @@ public class Compiler {
 
   private final LocalTable locals;
 
-  private int stackSize;
 
   private boolean isMacro;
 
   public Compiler() {
     quoteDepth = 0;
-    stackSize = 0;
     isMacro = false;
     className = String.format("Lambda%d", new Random().nextInt(1000000000));
     artifacts = new ArrayList<>();
@@ -142,9 +140,6 @@ public class Compiler {
   }
 
   private void finish() {
-    if (stackSize == 0) {
-      mv.visitInsn(ACONST_NULL);
-    }
     mv.visitInsn(ARETURN);
     mv.visitMaxs(0, 0);
     mv.visitEnd();
@@ -172,7 +167,6 @@ public class Compiler {
 
   private Metadata compileNumber(Integer integer) {
     mv.visitLdcInsn(integer);
-    stackSize++;
     mv.visitMethodInsn(
         INVOKESTATIC, "java/lang/Integer", "valueOf", "(I)Ljava/lang/Integer;", false);
     return new Metadata(Metadata.Type.INTEGER, integer.toString());
@@ -180,14 +174,12 @@ public class Compiler {
 
   private Metadata compileNumber(Float floating) {
     mv.visitLdcInsn(floating);
-    stackSize++;
     mv.visitMethodInsn(INVOKESTATIC, "java/lang/Float", "valueOf", "(F)Ljava/lang/Float;", false);
     return new Metadata(Metadata.Type.FLOAT, floating.toString());
   }
 
   private Metadata compileBoolean(Boolean bool) {
     mv.visitLdcInsn(bool);
-    stackSize++;
     mv.visitMethodInsn(
         INVOKESTATIC, "java/lang/Boolean", "valueOf", "(Z)Ljava/lang/Boolean;", false);
     return new Metadata(Metadata.Type.BOOLEAN, bool.toString());
@@ -195,13 +187,11 @@ public class Compiler {
 
   private Metadata compileString(String string) {
     mv.visitLdcInsn(string);
-    stackSize++;
     return new Metadata(Metadata.Type.STRING, string);
   }
 
   private Metadata compileSymbol(Symbol symbol) {
     Metadata meta = new Metadata(Metadata.Type.SYMBOL, symbol.getValue());
-    stackSize++;
     if (isQuoted() && !symbol.getValue().equals("nil")) {
       mv.visitTypeInsn(Opcodes.NEW, "ie/francis/lisp/type/Symbol");
       mv.visitInsn(DUP);
@@ -292,7 +282,6 @@ public class Compiler {
     }
     String descriptor = "(" + "Ljava/lang/Object;".repeat(size) + ")Ljava/lang/Object;";
 
-    stackSize += size;
     if (cons != null) {
       _compile(cons.getCar());
     }
@@ -307,12 +296,9 @@ public class Compiler {
     if (!evaluateArgs) {
       quoteDepth--;
     }
-    if (size != 0) {
-      stackSize--;
-    }
+
     mv.visitMethodInsn(
         INVOKEVIRTUAL, Apply.class.getName().replace(".", "/"), "call", descriptor, false);
-    stackSize++;
   }
 
   private void compileVariadicCall(Cons cons, boolean evaluateArgs) {
@@ -321,7 +307,6 @@ public class Compiler {
       size = cons.size();
     }
     String descriptor = "([Ljava/lang/Object;)Ljava/lang/Object;";
-    stackSize += size;
 
     mv.visitLdcInsn(size);
     mv.visitTypeInsn(ANEWARRAY, "java/lang/Object");
@@ -353,12 +338,8 @@ public class Compiler {
     if (!evaluateArgs) {
       quoteDepth--;
     }
-    if (size != 0) {
-      stackSize--;
-    }
     mv.visitMethodInsn(
         INVOKEVIRTUAL, Apply.class.getName().replace(".", "/"), "call", descriptor, false);
-    stackSize++;
   }
 
   private void compileConsWithoutEvaluating(Cons cons) {
@@ -369,27 +350,23 @@ public class Compiler {
       mv.visitInsn(DUP);
       mv.visitMethodInsn(INVOKESPECIAL, "ie/francis/lisp/type/Cons", "<init>", "()V", false);
       _compile(cons.getCar());
-      stackSize--;
       mv.visitMethodInsn(
           INVOKEVIRTUAL,
           "ie/francis/lisp/type/Cons",
           "setCar",
           "(Ljava/lang/Object;)Lie/francis/lisp/type/Cons;",
           false);
-      stackSize++;
       cons = cons.getCdr();
     }
 
     cons = head.getCdr();
     while (cons != null) {
-      stackSize--;
       mv.visitMethodInsn(
           INVOKEVIRTUAL,
           "ie/francis/lisp/type/Cons",
           "setCdr",
           "(Lie/francis/lisp/type/Cons;)Lie/francis/lisp/type/Cons;",
           false);
-      stackSize++;
       cons = cons.getCdr();
     }
   }
@@ -407,7 +384,6 @@ public class Compiler {
           mv.visitInsn(DUP);
           mv.visitMethodInsn(INVOKESPECIAL, lambda, "<init>", "()V", false);
           this.artifacts.addAll(compiler.artifacts);
-          stackSize++;
           break;
         }
       case "macro":
@@ -419,7 +395,6 @@ public class Compiler {
           mv.visitInsn(DUP);
           mv.visitMethodInsn(INVOKESPECIAL, macro, "<init>", "()V", false);
           this.artifacts.addAll(compiler.artifacts);
-          stackSize++;
           break;
         }
       case "quote":
@@ -461,9 +436,6 @@ public class Compiler {
         "put",
         "(Lie/francis/lisp/type/Symbol;Ljava/lang/Object;)Ljava/lang/Object;",
         false);
-    stackSize--;
-    stackSize--;
-    stackSize++;
   }
 
   // (let ([<a> <b>]+) form*)
@@ -480,8 +452,7 @@ public class Compiler {
       Metadata metadata = _compile(value);
       locals.add(symbol.getValue(), metadata);
       mv.visitVarInsn(ASTORE, locals.get(symbol.getValue()).getLocalId());
-      stackSize--;
-      // Move to next assignment if there is one
+            // Move to next assignment if there is one
       assignments = assignments.getCdr().getCdr();
     }
 

--- a/src/main/java/ie/francis/lisp/compiler/Compiler.java
+++ b/src/main/java/ie/francis/lisp/compiler/Compiler.java
@@ -453,16 +453,17 @@ public class Compiler {
     Symbol symbol = (Symbol) cons.getCdr().getCar();
     quoteDepth++;
     _compile(symbol);
-    stackSize--;
     quoteDepth--;
     _compile(cons.getCdr().getCdr().getCar());
-    stackSize--;
     mv.visitMethodInsn(
         INVOKESTATIC,
         "ie/francis/lisp/Environment",
         "put",
-        "(Lie/francis/lisp/type/Symbol;Ljava/lang/Object;)V",
+        "(Lie/francis/lisp/type/Symbol;Ljava/lang/Object;)Ljava/lang/Object;",
         false);
+    stackSize--;
+    stackSize--;
+    stackSize++;
   }
 
   // (let ([<a> <b>]+) form*)

--- a/src/test/java/ie/francis/lisp/compiler/CompilerTest.java
+++ b/src/test/java/ie/francis/lisp/compiler/CompilerTest.java
@@ -235,6 +235,12 @@ public class CompilerTest {
         assertEquals(5, output);
     }
 
+    @Test
+    void testExprAssignmentToSymbolSucceeds() {
+        eval("(def x (+ 1 2))");
+        assertEquals(eval("x"), 3);
+    }
+
     Object eval(String input) {
         Read reader = new Read();
         Eval eval = new Eval();

--- a/src/test/java/ie/francis/lisp/compiler/CompilerTest.java
+++ b/src/test/java/ie/francis/lisp/compiler/CompilerTest.java
@@ -237,11 +237,8 @@ public class CompilerTest {
 
     @Test
     void testExprAssignmentToSymbolSucceeds() {
-        eval("123");
-        eval("()");
-        eval("(def x 1)");
         eval("(def x (+ 1 2 3))");
-//        assertEquals(eval("x"), 3);
+        assertEquals(eval("x"), 6);
     }
 
     Object eval(String input) {

--- a/src/test/java/ie/francis/lisp/compiler/CompilerTest.java
+++ b/src/test/java/ie/francis/lisp/compiler/CompilerTest.java
@@ -237,8 +237,11 @@ public class CompilerTest {
 
     @Test
     void testExprAssignmentToSymbolSucceeds() {
-        eval("(def x (+ 1 2))");
-        assertEquals(eval("x"), 3);
+        eval("123");
+        eval("()");
+        eval("(def x 1)");
+        eval("(def x (+ 1 2 3))");
+//        assertEquals(eval("x"), 3);
     }
 
     Object eval(String input) {


### PR DESCRIPTION
Previously the compiler required a stackSize variable to keep track of the Java operand stack in each function. 

This was necessary because every function ended with an `ARETURN` instruction, however not every function returned a value which meant sometimes the operand stack was empty before calling the `ARETURN` instruction.

`ARETURN` expects an operand to be on the stack, otherwise the Java verifier will fail when trying to execute the class.

The solution to this problem was just to make Environment.put() return null rather than void. Now every function which is callable from Lisp returns an Object (which may be null) and there is no reason to track pushes and pops of the Java operand stack in the compiler anymore.

This simplifies the compiler and fixes a bug caused by not tracking the Java operand stack properly.

Prior to this bug fix
```
(def x (+ 1 2 3))
```
would cause the Java verifier to fail.

This is perfectly valid code but would cause a Java class verification error due to not keeping track of the operand stack in the compiler properly.